### PR TITLE
cmd: create configuration directory if it does not exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "kubeconfig-bikeshed"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubeconfig-bikeshed"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 authors = ["Marvin Beckers <mail@embik.me>"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,13 +6,25 @@ mod kubeconfig;
 use env_logger::Builder;
 use log::{self, SetLoggerError};
 use std::error::Error;
+use std::fs;
+use std::process;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let matches = cmd::cli().get_matches();
     let config_path = config::get_config_path()?;
 
     setup_logger(matches.get_flag("verbose"))?;
-    log::debug!("using {} as config path", config_path.display());
+    log::debug!("using {} as configuration directory", config_path.display());
+
+    if !config_path.is_dir() {
+        log::debug!("creating configuration directory as it does not exist");
+        fs::create_dir_all(&config_path).or_else(
+            |err: std::io::Error| -> Result<(), Box<dyn Error>> {
+                log::error!("failed to create directory: {err}");
+                process::exit(1);
+            },
+        )?;
+    }
 
     cmd::execute(&config_path, matches.subcommand())
 }


### PR DESCRIPTION
If `~/.config/kbs` doesn't exist, `kbs` currently fails. This adds functionality to create the directory if it doesn't exist.