### PR TITLE
shell: properly use alias in shell magic

### DIFF
--- a/src/cmd/shell/files/bash/kbs.source
+++ b/src/cmd/shell/files/bash/kbs.source
@@ -7,6 +7,6 @@ function kbs() {
         eval "$(_kbs_bin use $(_kbs_bin ls | _inline_fzf))"
     else
         # if parameters are passed, we just call the kbs binary directly
-        ${_kbs_bin} $@
+        _kbs_bin $@
     fi
 }

--- a/src/cmd/shell/files/zsh/kbs.source
+++ b/src/cmd/shell/files/zsh/kbs.source
@@ -7,6 +7,6 @@ function kbs() {
         eval "$(_kbs_bin use $(_kbs_bin ls | _inline_fzf))"
     else
         # if parameters are passed, we just call the kbs binary directly
-        ${_kbs_bin} $@
+        _kbs_bin $@
     fi
 }


### PR DESCRIPTION
This was a leftover and doesn't work with bash. it works in zsh, but that's by chance.