### PR TITLE
cmd/use: store last kubeconfig and make it available via `use -`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
-use std::env;
 use std::error::Error;
 use std::path::{Path, PathBuf};
+use std::{env, fs, io};
+
+const ACTIVE_FILE_NAME: &str = "active";
 
 pub fn get_config_path() -> Result<PathBuf, Box<dyn Error>> {
     // attempt to respect XDG_CONFIG_HOME, fall back to $HOME/.config if it's not set.
@@ -13,4 +15,12 @@ pub fn get_config_path() -> Result<PathBuf, Box<dyn Error>> {
     };
 
     Ok(path.join("kbs"))
+}
+
+pub fn get_last_active(config_path: &Path) -> io::Result<String> {
+    fs::read_to_string(config_path.join(ACTIVE_FILE_NAME))
+}
+
+pub fn save_last_active(config_path: &Path, name: &String) -> io::Result<()> {
+    fs::write(config_path.join(ACTIVE_FILE_NAME), name)
 }


### PR DESCRIPTION
Fixes #5.