### PR TITLE
import: add `--short` / `-s` flag to use first part of server FQDN as name

### DIFF
--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -51,6 +51,16 @@ pub fn command() -> Command {
                 .action(ArgAction::SetTrue)
                 .value_parser(clap::value_parser!(bool)),
         )
+        .arg(
+            Arg::new("short")
+                .help("Instead of using the FQDN of the server, just use the first part/subdomain")
+                .long("short")
+                .short('s')
+                .required(false)
+                .action(ArgAction::SetTrue)
+                .value_parser(clap::value_parser!(bool))
+                .conflicts_with("name"),
+        )
 }
 
 pub fn execute(config_dir: &Path, matches: &ArgMatches) -> Result<()> {
@@ -88,7 +98,11 @@ pub fn execute(config_dir: &Path, matches: &ArgMatches) -> Result<()> {
             let host = url
                 .host_str()
                 .ok_or_else(|| anyhow!("failed to parse host from server URL"))?;
-            host.to_string()
+
+            match matches.get_flag("short") {
+                true => host.split_once('.').unwrap_or((&host, "")).0.to_string(),
+                false => host.to_string(),
+            }
         }
     };
 

--- a/tests/files/localhost.kubeconfig
+++ b/tests/files/localhost.kubeconfig
@@ -1,0 +1,20 @@
+
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ""
+    server: https://localhost:6443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubernetes-admin
+  name: kubernetes-admin@kubernetes
+current-context: kubernetes-admin@kubernetes
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+  user:
+    client-certificate-data: ""
+    client-key-data: ""

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -153,6 +153,56 @@ fn test_kbs_import_with_labels() {
 }
 
 #[test]
+fn test_kbs_import_with_short_flag() {
+    let temp_dir = tempdir().unwrap();
+    let base_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/files");
+
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "import",
+            base_dir.join("test.kubeconfig").to_str().unwrap(),
+            "-s",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&["-c", temp_dir.path().to_str().unwrap(), "list"])
+        .assert()
+        .success()
+        .stdout(is_match("^kubernetes\n$").unwrap());
+}
+
+#[test]
+fn test_kbs_import_with_short_flag_localhost() {
+    let temp_dir = tempdir().unwrap();
+    let base_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/files");
+
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "import",
+            base_dir.join("localhost.kubeconfig").to_str().unwrap(),
+            "-s",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&["-c", temp_dir.path().to_str().unwrap(), "list"])
+        .assert()
+        .success()
+        .stdout(is_match("^localhost\n$").unwrap());
+}
+
+#[test]
 fn test_kbs_list_label_selector() {
     let temp_dir = tempdir().unwrap();
     let base_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/files");


### PR DESCRIPTION
Fixes #8.