### PR TITLE
metadata: rewrite label and selector support to support `key-` labels and `key!=value` selectors

### DIFF
--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -29,11 +29,11 @@ pub fn command() -> Command {
         .arg(
             Arg::new("labels")
                 .help("List of comma-separated key=value labels to add to the kubeconfig metadata")
-                .long("set-labels")
+                .long("labels")
                 .short('l')
                 .required(false)
                 .value_delimiter(',')
-                .value_parser(metadata::labels::parse_key_val),
+                .value_parser(labels::parse),
         )
         .arg(
             Arg::new("delete")
@@ -61,11 +61,7 @@ pub fn execute(config_dir: &Path, matches: &ArgMatches) -> Result<()> {
         .get_one::<PathBuf>("kubeconfig")
         .ok_or_else(|| anyhow!("failed to parse kubeconfig argument"))?;
 
-    // collect labels from argument into map
-    let labels = match matches.contains_id("labels") {
-        true => Some(labels::collect_from_args(matches, "labels")?),
-        false => None,
-    };
+    let labels = labels::from_args(matches, "labels")?;
 
     let metadata_path = metadata::file_path(config_dir);
     log::debug!("loading metadata from {}", metadata_path.display());
@@ -87,7 +83,12 @@ pub fn execute(config_dir: &Path, matches: &ArgMatches) -> Result<()> {
             matches.get_flag("short"),
         )?;
 
-        metadata = metadata.set(name, metadata::ConfigMetadata { labels });
+        metadata = metadata.set(
+            name,
+            metadata::ConfigMetadata {
+                labels: Some(labels::to_map(&labels)),
+            },
+        );
 
         if matches.get_flag("delete") {
             fs::remove_file(kubeconfig_path)?;
@@ -112,7 +113,7 @@ pub fn execute(config_dir: &Path, matches: &ArgMatches) -> Result<()> {
             metadata = metadata.set(
                 name.unwrap(),
                 metadata::ConfigMetadata {
-                    labels: labels.clone(),
+                    labels: Some(labels::to_map(&labels)),
                 },
             );
         }

--- a/src/cmd/remove.rs
+++ b/src/cmd/remove.rs
@@ -21,7 +21,7 @@ pub fn command() -> Command {
                 .short('l')
                 .num_args(0..)
                 .value_delimiter(',')
-                .value_parser(metadata::labels::parse_key_val),
+                .value_parser(metadata::selectors::parse),
         )
         .group(ArgGroup::new("target")
                .args(["kubeconfig", "selectors"])
@@ -40,11 +40,9 @@ pub fn execute(config_dir: &Path, matches: &ArgMatches) -> Result<()> {
 
     let removals = match matches.contains_id("selectors") {
         true => {
-            let selectors = matches
-                .get_many::<(String, String)>("selectors")
-                .map(|values_ref| values_ref.into_iter().collect::<Vec<&(String, String)>>());
+            let selectors = metadata::selectors::from_args(matches, "selectors")?;
 
-            kubeconfig::list(config_dir, &metadata, selectors.clone())?
+            kubeconfig::list(config_dir, &metadata, Some(selectors))?
         }
         false => {
             let config = matches

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -4,6 +4,9 @@ use std::collections::btree_map::BTreeMap;
 use std::{fs::File, path::Path, path::PathBuf};
 
 pub mod labels;
+pub mod selectors;
+
+pub use selectors::Selector;
 
 pub const FILE: &str = "metadata.json";
 

--- a/src/metadata/selectors.rs
+++ b/src/metadata/selectors.rs
@@ -1,0 +1,141 @@
+use super::labels;
+use crate::Error;
+use clap::ArgMatches;
+use std::collections::btree_map::BTreeMap;
+
+#[derive(Clone, PartialEq)]
+pub enum Operation {
+    Equal,
+    NotEqual,
+}
+
+#[derive(Clone)]
+pub struct Selector {
+    pub key: String,
+    pub value: String,
+    pub op: Operation,
+}
+
+pub fn matches(selectors: &Vec<Selector>, labels: &BTreeMap<String, String>) -> bool {
+    for selector in selectors.iter() {
+        let opt = labels.get(&selector.key);
+        if let Some(value) = opt {
+            if (selector.op == Operation::Equal && &selector.value != value)
+                || (selector.op == Operation::NotEqual && &selector.value == value)
+            {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+pub fn from_args(matches: &ArgMatches, id: &str) -> Result<Vec<Selector>, Error> {
+    if !matches.contains_id(id) {
+        return Ok(vec![]);
+    }
+
+    let labels = matches
+        .get_many::<Selector>(id)
+        .ok_or_else(|| Error::Message("failed to parse labels from argument".to_string()))?
+        .map(|l| l.to_owned())
+        .collect::<Vec<Selector>>();
+
+    Ok(labels)
+}
+
+// Parse a single selector from string
+pub fn parse(s: &str) -> Result<Selector, Error> {
+    let pos = s
+        .find('=')
+        .ok_or_else(|| Error::Message(format!("invalid selector: no `=` found in `{s}`")))?;
+    let mut key_end = pos.clone();
+    let mut op = Operation::Equal;
+
+    // check if '!' is in the string and right before the '='
+    if let Some(pos_bang) = s.find('!') {
+        if pos_bang == pos - 1 {
+            op = Operation::NotEqual;
+            key_end = pos - 1;
+        }
+    }
+
+    let key = &s[..key_end];
+    let value = &s[pos + 1..];
+
+    if !labels::is_valid_label_key(key) || !labels::is_valid_label_value(value) {
+        return Err(Error::Message(
+            "key or value are not valid RFC 1123 dns-style".to_string(),
+        ));
+    }
+
+    Ok(Selector {
+        key: key.to_string(),
+        value: value.to_string(),
+        op,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata;
+    use crate::metadata::labels::Label;
+
+    #[test]
+    fn test_parse() {
+        for selector in &["test=test", "test!=test.com", "test=test.com"] {
+            let s = parse(selector);
+            assert!(s.is_ok());
+            assert_eq!(s.unwrap().key, "test");
+        }
+    }
+
+    #[test]
+    fn test_matches() {
+        let tests: Vec<(Vec<Selector>, Vec<Label>, bool)> = vec![
+            (
+                vec![Selector {
+                    key: "key".to_string(),
+                    value: "val".to_string(),
+                    op: Operation::Equal,
+                }],
+                vec![],
+                false,
+            ),
+            (
+                vec![Selector {
+                    key: "key".to_string(),
+                    value: "val".to_string(),
+                    op: Operation::Equal,
+                }],
+                vec![Label {
+                    key: "key".to_string(),
+                    value: Some("val".to_string()),
+                }],
+                true,
+            ),
+            (
+                vec![Selector {
+                    key: "key".to_string(),
+                    value: "val".to_string(),
+                    op: Operation::NotEqual,
+                }],
+                vec![Label {
+                    key: "key".to_string(),
+                    value: Some("val".to_string()),
+                }],
+                false,
+            ),
+        ];
+
+        for test in tests.iter() {
+            let (selectors, labels, expected) = test;
+            let labels_map = metadata::labels::to_map(&labels);
+            assert_eq!(matches(&selectors, &labels_map), expected.to_owned());
+        }
+    }
+}

--- a/tests/label.rs
+++ b/tests/label.rs
@@ -95,3 +95,79 @@ fn test_kbs_label_add_by_selector() {
         .success()
         .stdout(is_match("^kubernetes.embik.me\n$").unwrap());
 }
+
+#[test]
+fn test_kbs_label_remove() {
+    let temp_dir = tempdir().unwrap();
+    let base_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/files");
+
+    // initial import should succeed.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "import",
+            base_dir.join("test.kubeconfig").to_str().unwrap(),
+            "-l",
+            "new-label=new-value,old-label=old-value",
+        ])
+        .assert()
+        .success();
+
+    // assert that imported kubeconfig shows up under new label.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "list",
+            "-l",
+            "new-label=new-value",
+        ])
+        .assert()
+        .success()
+        .stdout(is_match("^kubernetes.embik.me\n$").unwrap());
+
+    // remove label from the imported kubeconfig.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "label",
+            "--name",
+            "kubernetes.embik.me",
+            "new-label-",
+        ])
+        .assert()
+        .success();
+
+    // assert that imported kubeconfig no longer shows up under removed label.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "list",
+            "-l",
+            "new-label=new-value",
+        ])
+        .assert()
+        .success()
+        .stdout(is_match("^$").unwrap());
+
+    // assert that imported kubeconfig still shows up under old label.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "list",
+            "-l",
+            "old-label=old-value",
+        ])
+        .assert()
+        .success()
+        .stdout(is_match("^kubernetes.embik.me\n$").unwrap());
+}


### PR DESCRIPTION
Fixes #36.

While implementing the issue linked above, I ended up completely rewriting the support for labels and selectors in the code. This brings two features:

- labels can be marked as "to be removed" with the `key-` syntax (mostly applies to `kbs label`)
- selectors now support "not equal" as operation with `key!=value` (in all commands that support selectors, e.g. `kbs list`, `kbs prune` or `kbs delete`)