### PR TITLE
metadata: correctly match on not equal selectors

### DIFF
--- a/src/metadata/selectors.rs
+++ b/src/metadata/selectors.rs
@@ -25,7 +25,9 @@ pub fn matches(selectors: &[Selector], labels: &BTreeMap<String, String>) -> boo
             {
                 return false;
             }
-        } else {
+        } else if selector.op == Operation::Equal {
+            // if the label doesn't exist, we only have to return "false"
+            // if the operation was an equal check. For NotEqual we're good.
             return false;
         }
     }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -52,3 +52,83 @@ fn test_kbs_list_label_selector() {
         .success()
         .stdout(is_match("^kubernetes.beckers.dev\n$").unwrap());
 }
+
+#[test]
+fn test_kbs_list_label_selector_not_equal() {
+    let temp_dir = tempdir().unwrap();
+    let base_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/files");
+
+    // initial import should succeed.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "import",
+            base_dir.join("test.kubeconfig").to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // initial import should succeed.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "import",
+            base_dir.join("test.kubeconfig").to_str().unwrap(),
+            "-l",
+            "location=imagination,owner=embik",
+            "-n",
+            "kubernetes.beckers.dev",
+        ])
+        .assert()
+        .success();
+
+    // initial import should succeed.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "import",
+            base_dir.join("test.kubeconfig").to_str().unwrap(),
+            "-l",
+            "location=narnia,owner=notembik",
+            "-n",
+            "kubernetes.not.embik.me",
+        ])
+        .assert()
+        .success();
+
+    // assert that only one of the imported kubeconfigs is returned,
+    // namely the one matching the label.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "list",
+            "-l",
+            "location=imagination",
+        ])
+        .assert()
+        .success()
+        .stdout(is_match("^kubernetes.beckers.dev\n$").unwrap());
+
+    // assert that the two kubeconfigs that are not labeled location=imagination
+    // are returned.
+    Command::cargo_bin("kbs")
+        .unwrap()
+        .args(&[
+            "-c",
+            temp_dir.path().to_str().unwrap(),
+            "list",
+            "-l",
+            "location!=imagination",
+        ])
+        .assert()
+        .success()
+        .stdout(is_match("^kubernetes.embik.me\nkubernetes.not.embik.me\n$").unwrap());
+}


### PR DESCRIPTION
I noticed that the `key!=value` selector wouldn't return any kubeconfigs that didn't have the label at all (which still makes them eligible for this kind of selector). This should fix it.